### PR TITLE
fix: :building_construction: Bump from `py<3.11` to `py<3.12`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7d5c514f87366164190c904bf4b89ecc80222a2a94a5d2c2a24a2b3240ebca2b
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ name|lower }}
@@ -24,11 +24,11 @@ outputs:
         - spectrafit-data-converter = spectrafit.plugins.data_converter:command_line_runner
     requirements:
       host:
-        - python >=3.8, <3.11
+        - python >=3.8, <3.12
         - pip
         - poetry
       run:
-        - python >=3.8, <3.11
+        - python >=3.8, <3.12
         - pyyaml
         - ascii-art
         - emcee
@@ -93,7 +93,7 @@ outputs:
         - spectrafit-pkl-visualizer = spectrafit.plugins.pkl_visualizer:command_line_runner
         - spectrafit-pkl-converter = spectrafit.plugins.pkl_converter:command_line_runner
       host:
-        - python >=3.8, <3.11
+        - python >=3.8, <3.12
         - pip
         - poetry
     requirements:
@@ -120,7 +120,7 @@ outputs:
         - spectrafit-rixs-visualizer = spectrafit.plugins.rixs_visualizer:command_line_runner
         - spectrafit-rixs-converter = spectrafit.plugins.rixs_converter:command_line_runner
       host:
-        - python >=3.8, <3.11
+        - python >=3.8, <3.12
         - pip
         - poetry
     requirements:
@@ -147,7 +147,7 @@ outputs:
       noarch: python
       skip: true  # [not linux64]
       host:
-        - python >=3.8, <3.11
+        - python >=3.8, <3.12
         - pip
         - poetry
     requirements:


### PR DESCRIPTION
Correct outdated python dependencies from `<3.11` to `<3.12`.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
